### PR TITLE
Unlimited buttons

### DIFF
--- a/UIActionSheet+Blocks.m
+++ b/UIActionSheet+Blocks.m
@@ -39,11 +39,35 @@ static const void *UIActionSheetWillDismissBlockKey = &UIActionSheetWillDismissB
 static const void *UIActionSheetDidDismissBlockKey  = &UIActionSheetDidDismissBlockKey;
 static const void *UIActionSheetCancelBlockKey      = &UIActionSheetCancelBlockKey;
 
-#define NSArrayObjectMaybeNil(__ARRAY__, __INDEX__) ((__INDEX__ >= [__ARRAY__ count]) ? nil : [__ARRAY__ objectAtIndex:__INDEX__])
-// This is a hack to turn an array into a variable argument list. There is no good way to expand arrays into variable argument lists in Objective-C. This works by nil-terminating the list as soon as we overstep the bounds of the array. The obvious glitch is that we only support a finite number of buttons.
-#define NSArrayToVariableArgumentsList(__ARRAYNAME__) NSArrayObjectMaybeNil(__ARRAYNAME__, 0), NSArrayObjectMaybeNil(__ARRAYNAME__, 1), NSArrayObjectMaybeNil(__ARRAYNAME__, 2), NSArrayObjectMaybeNil(__ARRAYNAME__, 3), NSArrayObjectMaybeNil(__ARRAYNAME__, 4), NSArrayObjectMaybeNil(__ARRAYNAME__, 5), NSArrayObjectMaybeNil(__ARRAYNAME__, 6), NSArrayObjectMaybeNil(__ARRAYNAME__, 7), NSArrayObjectMaybeNil(__ARRAYNAME__, 8), NSArrayObjectMaybeNil(__ARRAYNAME__, 9), nil
 
 @implementation UIActionSheet (Blocks)
+
+
+- (instancetype)initWithTitle:(NSString *)title
+                     delegate:(id<UIActionSheetDelegate>)delegate
+            cancelButtonTitle:(NSString *)cancelButtonTitle
+       destructiveButtonTitle:(NSString *)destructiveButtonTitle
+       otherButtonTitlesArray:(NSArray *)otherButtonTitles {
+    
+    UIActionSheet *actionSheet = [[UIActionSheet alloc] initWithTitle:title
+                                                             delegate:nil
+                                                    cancelButtonTitle:nil
+                                               destructiveButtonTitle:nil
+                                                    otherButtonTitles:nil];
+    if (destructiveButtonTitle) {
+         actionSheet.destructiveButtonIndex = [actionSheet addButtonWithTitle:destructiveButtonTitle];
+    }
+    
+    for (NSString *title in otherButtonTitles) {
+        [actionSheet addButtonWithTitle:title];
+    }
+
+    if (cancelButtonTitle) {
+        actionSheet.cancelButtonIndex = [actionSheet addButtonWithTitle:cancelButtonTitle];
+    }
+    
+    return actionSheet;
+}
 
 + (instancetype)showFromTabBar:(UITabBar *)tabBar
                      withTitle:(NSString *)title
@@ -56,7 +80,7 @@ static const void *UIActionSheetCancelBlockKey      = &UIActionSheetCancelBlockK
                                                     delegate:nil
                                            cancelButtonTitle:cancelButtonTitle
                                       destructiveButtonTitle:destructiveButtonTitle
-                                           otherButtonTitles:NSArrayToVariableArgumentsList(otherButtonTitles)];
+                                           otherButtonTitlesArray:otherButtonTitles];
 
     if (tapBlock) {
         actionSheet.tapBlock = tapBlock;
@@ -82,7 +106,7 @@ static const void *UIActionSheetCancelBlockKey      = &UIActionSheetCancelBlockK
                                                     delegate:nil
                                            cancelButtonTitle:cancelButtonTitle
                                       destructiveButtonTitle:destructiveButtonTitle
-                                           otherButtonTitles:NSArrayToVariableArgumentsList(otherButtonTitles)];
+                                           otherButtonTitlesArray:otherButtonTitles];
 
     if (tapBlock) {
         actionSheet.tapBlock = tapBlock;
@@ -108,7 +132,7 @@ static const void *UIActionSheetCancelBlockKey      = &UIActionSheetCancelBlockK
                                                     delegate:nil
                                            cancelButtonTitle:cancelButtonTitle
                                       destructiveButtonTitle:destructiveButtonTitle
-                                           otherButtonTitles:NSArrayToVariableArgumentsList(otherButtonTitles)];
+                                           otherButtonTitlesArray:otherButtonTitles];
 
     if (tapBlock) {
         actionSheet.tapBlock = tapBlock;
@@ -135,7 +159,7 @@ static const void *UIActionSheetCancelBlockKey      = &UIActionSheetCancelBlockK
                                                     delegate:nil
                                            cancelButtonTitle:cancelButtonTitle
                                       destructiveButtonTitle:destructiveButtonTitle
-                                           otherButtonTitles:NSArrayToVariableArgumentsList(otherButtonTitles)];
+                                           otherButtonTitlesArray:otherButtonTitles];
 
     if (tapBlock) {
         actionSheet.tapBlock = tapBlock;
@@ -163,7 +187,7 @@ static const void *UIActionSheetCancelBlockKey      = &UIActionSheetCancelBlockK
                                                     delegate:nil
                                            cancelButtonTitle:cancelButtonTitle
                                       destructiveButtonTitle:destructiveButtonTitle
-                                           otherButtonTitles:NSArrayToVariableArgumentsList(otherButtonTitles)];
+                                           otherButtonTitlesArray:otherButtonTitles];
 
     if (tapBlock) {
         actionSheet.tapBlock = tapBlock;

--- a/UIActionSheet+Blocks.podspec
+++ b/UIActionSheet+Blocks.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "UIActionSheet+Blocks"
-  s.version      = "0.8.1"
+  s.version      = "0.8.2"
   s.summary      = "Category on UIActionSheet to use inline block callbacks instead of delegate callbacks."
 
   s.description  = <<-DESC
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.license      = { :type => 'MIT', :file => 'LICENSE' }
   s.author       = { "Ryan Maxwell" => "ryanm@xwell.co.nz" }
   s.platform     = :ios, '4.3'
-  s.source       = { :git => "https://github.com/ryanmaxwell/UIActionSheet-Blocks.git", :tag => "0.8.1" }
+  s.source       = { :git => "https://github.com/ryanmaxwell/UIActionSheet-Blocks.git", :tag => "0.8.2" }
   s.source_files = 'UIActionSheet+Blocks.{h,m}'
   s.requires_arc = true
 end


### PR DESCRIPTION
I needed more than 10 buttons for a selection list and I saw the macro expanding the list of buttons was not the perfect solution.

I remove the macros and created a method with similar signature to the UIActionSheet init method but taking the array instead of the list of arguments. Using UIActionSheet methods I configure the list of buttons as it would look if added with the default init method.

I changed all code to use the new method when needed.
